### PR TITLE
IFLEARN-8 Add Clang Formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,37 @@
+---
+# Based on Google style with customizations
+BasedOnStyle: Google
+Language:     Cpp
+
+# Indent with 4 spaces
+IndentWidth: 4
+ContinuationIndentWidth: 4
+
+# Pointer and reference alignment with type
+PointerAlignment: Left
+ReferenceAlignment: Left
+
+# All curly braces on their own line (Allman style)
+BreakBeforeBraces: Allman
+
+# Keep a maximum of 2 consecutive empty lines
+MaxEmptyLinesToKeep: 2
+
+# Break constructor initializer lists before the comma
+BreakConstructorInitializersBeforeComma: true
+
+# Include sorting: local ("") first, then system (<>), alphabetically
+SortIncludes: CaseSensitive
+IncludeBlocks: Merge
+IncludeCategories:
+  - Regex:           '^".*"'
+    Priority:        1
+  - Regex:           '^<.*>'
+    Priority:        2
+
+# Additional formatting options
+ColumnLimit: 80
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: Always
+AllowShortLoopsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never


### PR DESCRIPTION
**Description**
This PR adds a clang-formatting file with some basic initial settings to ensure all of the code in this branch is aligned in style.

**What is the current behavior, before this PR?**
There was no clang formatting.

**What is the new behavior, in this PR?**
Now there is.

**Jira Issue Number**
Closes #8

**How This Has Been Tested**
I installed Clang Power Tools, and tried formatting a few test files, and it seems to be good.

**Secondary Impacts**
None.

**Reviewer Suggestions**
Just read the file.

**Reminder of our Reviewer Checklist**
Code exhibits correct behavior.
Code conforms to our style and standards.
The purpose/intent of all code blocks is clear.
The contracts of all code constructs are clear.
Automated tests exercise the affected code.
Documentation has been updated to reflect the changes.
CI jobs are green.